### PR TITLE
If snot fails to schedule a test set the name of the test to the failure message

### DIFF
--- a/snot.py
+++ b/snot.py
@@ -411,6 +411,8 @@ class SlickAsSnotPlugin(nose.plugins.Plugin):
                     for attribute_name, attribute_value in testdata.__dict__.items():
                         if attribute_name == 'name':
                             pass
+                        elif attribute_name == 'automationId' and attribute_value == 'nose.failure.Failure.runTest':
+                            setattr(slicktest, 'name', "{}: {} ({})".format(type(test.test).__name__, type(test.test.exc_val).__name__, test.test.exc_val.message))
                         elif attribute_name in slicktest._fields.keys():
                             setattr(slicktest, attribute_name, attribute_value)
                         elif attribute_name not in ('expectedResults', 'component', 'steps'):


### PR DESCRIPTION
I think this would be really handy when trying to debug scheduling problems rather than a bunch of results that say `Run`. Here's what it looks like:

<img width="1336" alt="screen shot 2018-04-19 at 5 03 03 pm" src="https://user-images.githubusercontent.com/10365264/39022617-9e9042cc-43f3-11e8-80e7-0d4ab896a471.png">

Here's what it used to look like:

<img width="1336" alt="screen shot 2018-04-19 at 5 04 51 pm" src="https://user-images.githubusercontent.com/10365264/39022661-d2e8ad84-43f3-11e8-91e8-0482c899b002.png">

